### PR TITLE
Add assert statements to document key assumptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ checkstyle {
     toolVersion = '11.0.0'
 }
 
-run{
+run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/MainWindow.java
+++ b/src/main/java/MainWindow.java
@@ -49,6 +49,11 @@ public class MainWindow extends AnchorPane {
     @FXML
     private void handleUserInput() {
         String input = userInput.getText();
+
+        if (input.isEmpty()) {
+            return;
+        }
+
         Stage stage = (Stage) scrollPane.getScene().getWindow();
 
         String response = keef.getResponse(input, stage);

--- a/src/main/java/keef/command/AddDeadlineCommand.java
+++ b/src/main/java/keef/command/AddDeadlineCommand.java
@@ -64,7 +64,11 @@ public class AddDeadlineCommand extends Command {
 
         // Create the deadline task
         deadlineTask = new Deadline(description, by);
+
+        int before = tasks.getSize();
         tasks.addTask(deadlineTask);
+        assert deadlineTask != null : "Deadline Task should be created successfully";
+        assert tasks.getSize() == before + 1 : "Task list size should increase by 1";
 
         // Save and show message
         storage.saveTasks(tasks);

--- a/src/main/java/keef/command/AddEventCommand.java
+++ b/src/main/java/keef/command/AddEventCommand.java
@@ -71,7 +71,11 @@ public class AddEventCommand extends Command {
 
         // Create the event task
         eventTask = new Event(description, from, to);
+
+        int before = tasks.getSize();
         tasks.addTask(eventTask);
+        assert eventTask != null : "Event Task should be created successfully";
+        assert tasks.getSize() == before + 1 : "Task list size should increase by 1";
 
         // Save and show message
         storage.saveTasks(tasks);

--- a/src/main/java/keef/command/AddTodoCommand.java
+++ b/src/main/java/keef/command/AddTodoCommand.java
@@ -41,7 +41,11 @@ public class AddTodoCommand extends Command {
 
         // Create the todo task
         Task task = new ToDo(description);
+
+        int before = tasks.getSize();
         tasks.addTask(task);
+        assert task != null : "ToDo Task should be created successfully";
+        assert tasks.getSize() == before + 1 : "Task list size should increase by 1";
 
         // Save and show message
         storage.saveTasks(tasks);

--- a/src/main/java/keef/parser/Parser.java
+++ b/src/main/java/keef/parser/Parser.java
@@ -28,10 +28,14 @@ public class Parser {
      * @throws KeefException if the command is invalid or unrecognized
      */
     public static Command parse(String fullCommand, Stage stage) throws KeefException {
+        assert fullCommand != null : "Full command should not be null";
+
         // Split the command into its arguments
         String[] parts = fullCommand.trim().split(" ", 2);
         String commandWord = parts[0].toUpperCase();
         String arguments = parts.length > 1 ? parts[1] : "";
+
+        assert !commandWord.isBlank() : "Command word should not be blank";
 
         // Get the command type to execute
         CommandType type = CommandType.fromString(commandWord);
@@ -61,6 +65,9 @@ public class Parser {
      * @throws KeefException if the string is not a valid number or is out of bounds
      */
     public static int parseTaskIndex(String arguments, int max) throws KeefException {
+        assert arguments != null : "Arguments should not be null";
+        assert max >= 0 : "Max task count should not be negative";
+
         int taskIndex;
         try {
             taskIndex = Integer.parseInt(arguments.trim());

--- a/src/main/java/keef/storage/Storage.java
+++ b/src/main/java/keef/storage/Storage.java
@@ -27,6 +27,9 @@ public class Storage {
      * @param filePath the path to the file used for storing tasks
      */
     public Storage(String filePath) {
+        assert filePath != null : "File path should not be null";
+        assert !filePath.isBlank() : "File path should not be blank";
+
         this.filePath = filePath;
     }
 
@@ -59,9 +62,20 @@ public class Storage {
                 boolean isDone = parts[1].equals("1");
                 Task task = switch (type) {
                     //CHECKSTYLE.OFF: Indentation
-                    case "T" -> new ToDo(parts[2]);
-                    case "D" -> new Deadline(parts[2], LocalDateTime.parse(parts[3]));
-                    case "E" -> new Event(parts[2], LocalDateTime.parse(parts[3]), LocalDateTime.parse(parts[3]));
+                    case "T" -> {
+                        assert parts.length == 3 : "ToDo should have exactly 3 fields";
+                        yield new ToDo(parts[2]);
+                    }
+                    case "D" -> {
+                        assert parts.length == 4 : "Deadline should have exactly 4 fields";
+                        yield new Deadline(parts[2], LocalDateTime.parse(parts[3]));
+                    }
+                    case "E" -> {
+                        assert parts.length == 5 : "Event should have exactly 5 fields";
+                        yield new Event(parts[2],
+                                LocalDateTime.parse(parts[3]),
+                                LocalDateTime.parse(parts[4]));
+                    }
                     default -> null;
                     //CHECKSTYLE.ON: Indentation
                 };
@@ -99,7 +113,6 @@ public class Storage {
             }
 
             FileWriter writer = new FileWriter(dataFile);
-            System.out.println("Saving " + tasks.getSize() + " tasks");
 
             // Extract and write details about the task into the datafile
             for (Task task : tasks.getAllTasks()) {


### PR DESCRIPTION
Several methods in the Keef application assume certain invariants, such as non-null tasks being added to the TaskList, valid command parsing, and non-empty user inputs.

These assumptions were not explicitly documented in the code, making it harder to detect logic errors during development or testing.

Let's,
* assert that newly created tasks are not null before adding to TaskList
* assert that command parsing returns a non-null Command object
* assert that input strings are non-empty before processing

Adding assertions provides a lightweight mechanism to catch violations early and serves as in-code documentation of the expected state.

This improves code reliability and helps future maintainers understand assumptions.